### PR TITLE
Origin podcast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nd-storybook/storybook",
-  "version": "0.3.56",
+  "version": "0.3.57",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,9 @@ export type { BezorgingStopzettenProps } from './organisms/MijnNdOrganisms/Bezor
 export { AfwijkendBezorgAdres } from './organisms/MijnNdOrganisms/AfwijkendBezorgAdres/AfwijkendBezorgAdres.tsx';
 export type { AfwijkendBezorgAdresProps } from './organisms/MijnNdOrganisms/AfwijkendBezorgAdres/AfwijkendBezorgAdres.tsx';
 
+export { PodcastSeriesOverview } from './organisms/PodcastOrganisms/PodcastSeriesOverview/PodcastSeriesOverview';
+export type { PodcastSeriesOverviewProps, PodcastSeries } from './organisms/PodcastOrganisms/PodcastSeriesOverview/PodcastSeriesOverview';
+
 // Hooks
 export { useFetchData } from './hooks/useFetchData';
 export { useFetchList } from './hooks/useFetchList';

--- a/src/organisms/PodcastOrganisms/PodcastSeriesOverview/PodcastSeriesOverview.tsx
+++ b/src/organisms/PodcastOrganisms/PodcastSeriesOverview/PodcastSeriesOverview.tsx
@@ -13,27 +13,25 @@ export interface PodcastSeriesOverviewProps {
     series: PodcastSeries[];
 }
 
-const PodcastSeriesCard: React.FC<PodcastSeries> = ({ imageUrl, alt, title, description, metaText, href }) => {
+export const PodcastSeriesCard: React.FC<PodcastSeries> = ({ imageUrl, alt, title, description, metaText, href }) => {
     const inner = (
-        <div className="flex flex-row sm:flex-col sm:pt-s sm:px-s h-full">
-            <div className="shrink-0 w-1/3 aspect-square self-start sm:w-full sm:self-auto overflow-hidden">
+        <div className="flex flex-col h-full">
+            <div className="w-full overflow-hidden">
                 {imageUrl ? (
-                    <img src={imageUrl} alt={alt} className="w-full h-full object-cover" />
+                    <img src={imageUrl} alt={alt} className="w-full h-auto object-cover" />
                 ) : (
-                    <div className="w-full h-full bg-background-gray" />
+                    <div className="w-full aspect-square bg-background-gray" />
                 )}
             </div>
-            <div className="flex flex-col p-xxs pl-s sm:pl-0 sm:py-s flex-1 min-w-0 justify-center sm:justify-between">
-                <div className="flex flex-col gap-xxs">
-                    <span className="text-heading-m text-text-default">{title}</span>
-                    {description && (
-                        <span className="text-meta-light text-text-default line-clamp-3">{description}</span>
-                    )}
-                </div>
+            <div className="flex flex-col p-s flex-1 min-w-0">
+                <span className="text-heading-m text-text-default">{title}</span>
+                {description && (
+                    <span className="text-meta-light text-text-default line-clamp-3 mt-xxs">{description}</span>
+                )}
                 {metaText && (
-                    <a href={href} className="text-meta-light text-text-gray mt-xxs sm:mt-0 sm:pt-s">
+                    <span className="text-meta-light text-text-gray mt-s">
                         {metaText} &gt;
-                    </a>
+                    </span>
                 )}
             </div>
         </div>
@@ -41,7 +39,7 @@ const PodcastSeriesCard: React.FC<PodcastSeries> = ({ imageUrl, alt, title, desc
 
     if (href) {
         return (
-            <a href={href} className="flex flex-col group border border-width-default border-border-gray-subtle hover:border-border-brand">
+            <a href={href} className="flex flex-col border border-width-default border-border-gray-subtle hover:border-border-brand">
                 {inner}
             </a>
         );


### PR DESCRIPTION
Replace carousel HTML with React PodcastSeriesOverview via data-props hydration.
Map dossier data to component props, strip HTML from Body field.
Register component in app.tsx and export from Storybook index.
Fix card layout: always stack vertically, remove nested anchor tag.